### PR TITLE
环规署 黄俊皓 泛非通讯社

### DIFF
--- a/_posts/2019-7-29-title.markdown
+++ b/_posts/2019-7-29-title.markdown
@@ -1,0 +1,10 @@
+layout:post
+title:叙利亚代表怒斥美英法
+subtitle:无
+date:2019-7-29
+author:"泛非通讯社  黄俊皓"
+header-img：https://imgchr.com/i/e3Z0bj
+tags：
+  -泛非通讯社 
+  -环规署
+  -黄俊皓


### PR DESCRIPTION
4月13日，美国联合英国、法国，未经联合国安理会授权，对叙利亚发动武装军事打击。引起叙利亚人民公愤，次日，联合国召开紧急会议。叙利亚代表表示英法美在无视现有的国际秩序，并当场掏出《联合国宪章》。
俄罗斯在安理会起草了旨在谴责对叙利亚进行军事打击的决议草案，中国是三个投了赞成票的国家之一，不过草案并未通过。