### PR TITLE
环规署 梁国泰 美联社

### DIFF
--- a/2019-7-29-title.markdown
+++ b/2019-7-29-title.markdown
@@ -1,0 +1,10 @@
+layout:  post   
+title:  "叙利亚联合国代表怒斥英美法骗子伪君子"   
+subtitle:  "忍无可忍"   
+date:  2019-07-29  
+author:  "美联社 梁国泰"  
+header-img:！[环规署](https://imgchr.com/i/e3Etot)   
+tags:    
+  -美联社  
+  -环规署  
+  -梁国泰    


### PR DESCRIPTION
叙利亚联合国代表怒斥英美法骗子伪君子，还讽刺英美法不懂《联合国宪章》。叙利亚代表对英法美以化武为由发动袭击表示不屑，问道既然英美法认为他们的袭击摧毁了叙利亚政府的“化武设施”，那为什么他们没有向国际禁化武组织或其他国际组织通报那些所谓的设施？美联社记者认为，这样的讽刺可能会引起英美法代表的极度不满，应该尽早地解决这个问题，动议解决方案。